### PR TITLE
DeepMobLearningのバランス調整を実施

### DIFF
--- a/config/deepmoblearning.cfg
+++ b/config/deepmoblearning.cfg
@@ -193,16 +193,16 @@ general {
     I:killMultiplierTier3=18
 
     # Number of kills to reach the Basic tier.
-    I:killsToTier1=6
+    I:killsToTier1=25
 
     # Number of kills to reach the Advanced tier.
-    I:killsToTier2=12
+    I:killsToTier2=75
 
     # Number of kills to reach the Superior tier.
-    I:killsToTier3=30
+    I:killsToTier3=200
 
     # Number of kills to reach the Self Aware tier.
-    I:killsToTier4=50
+    I:killsToTier4=1000
 }
 
 
@@ -249,13 +249,12 @@ general {
         minecraft:dragon_breath,32,0
         minecraft:dragon_egg,1,0
         draconicevolution:dragon_heart,1,0
-        draconicevolution:draconium_dust,64,0
+        draconicevolution:draconium_dust,4,0
      >
 
     # Enderman
     S:enderman <
         minecraft:ender_pearl,6,0
-        minecraft:end_crystal,1,0
         enderio:block_enderman_skull,2,0
      >
 
@@ -274,7 +273,6 @@ general {
     # Shulker
     S:shulker <
         minecraft:shulker_shell,18,0
-        minecraft:diamond,2,0
      >
 
     # Skeleton
@@ -318,28 +316,25 @@ general {
 
     # Witch
     S:witch <
-        minecraft:redstone,32,0
-        minecraft:glowstone_dust,32,0
         minecraft:sugar,64,0
      >
 
     # Wither
     S:wither <
-        minecraft:nether_star,3,0
+        minecraft:nether_star,1,0
      >
 
     # Wither Skeleton
     S:witherskeleton <
         minecraft:skull,18,1
-        minecraft:coal,64,0
+        minecraft:coal,24,0
      >
 
     # Zombie
     S:zombie <
         minecraft:rotten_flesh,64,0
-        minecraft:iron_ingot,16,0
-        minecraft:carrot,32,0
-        minecraft:potato,32,0
+        minecraft:carrot,8,0
+        minecraft:potato,8,0
      >
 }
 

--- a/scripts/DeepMobLearning.zs
+++ b/scripts/DeepMobLearning.zs
@@ -1,0 +1,38 @@
+val large_obsidian = <tconstruct:large_plate>.withTag({Material: "obsidian"});
+
+// Soot-covered Plate
+recipes.remove(<deepmoblearning:soot_covered_plate>);
+recipes.addShaped(<deepmoblearning:soot_covered_plate> * 1, [[null, large_obsidian, null], [large_obsidian, <deepmoblearning:soot_covered_redstone>, large_obsidian],[null, large_obsidian, null]]);
+
+// Soot-covered Machine Casing
+recipes.remove(<deepmoblearning:machine_casing>);
+recipes.addShaped(<deepmoblearning:machine_casing> * 1, [[<deepmoblearning:soot_covered_plate>, <deepmoblearning:soot_covered_plate>, <deepmoblearning:soot_covered_plate>], [<thermalfoundation:material:27>, <deepmoblearning:soot_covered_redstone>, <thermalfoundation:material:27>],[<deepmoblearning:soot_covered_plate>, <deepmoblearning:soot_covered_plate>, <deepmoblearning:soot_covered_plate>]]);
+
+// Polymer Clay
+recipes.remove(<deepmoblearning:polymer_clay>);
+recipes.addShaped(<deepmoblearning:polymer_clay> * 32, [[<industrialforegoing:plastic>, <enderio:item_material:72>, <enderio:item_alloy_ingot:5>], [<enderio:item_material:72>, <minecraft:lapis_block>, <enderio:item_material:72>],[<enderio:item_alloy_ingot:7>, <enderio:item_material:72>, <industrialforegoing:plastic>]]);
+
+# - マターから作るレシピを一部削除
+
+# --- 鉄
+recipes.removeShapeless(<minecraft:iron_ingot>*8, [
+    <deepmoblearning:living_matter_overworldian>,
+    <deepmoblearning:living_matter_overworldian>,
+    <deepmoblearning:living_matter_overworldian>,
+    <deepmoblearning:living_matter_overworldian>,
+    <minecraft:rotten_flesh>
+]);
+
+# --- 金
+recipes.removeShapeless(<minecraft:gold_ingot>*6, [
+    <deepmoblearning:living_matter_hellish>,
+    <minecraft:glowstone_dust>,
+    <minecraft:iron_ingot>
+]);
+
+# --- ネザースター
+recipes.removeShaped(<minecraft:nether_star>, [
+    [<minecraft:skull:1>, <deepmoblearning:living_matter_extraterrestrial>, <minecraft:skull:1>],
+    [<minecraft:soul_sand>, <minecraft:soul_sand>, <minecraft:soul_sand>],
+    [null, <minecraft:soul_sand>, null],
+]);


### PR DESCRIPTION
refs - #28
* Soot-covered obsidianを含むレシピの変更
* Pristine Matterや通常マターから鉄、金、赤石、グロウストーンを作るレシピを削除
* Pristine Matterによるドロップアイテムの作成レシピをナーフ
* DMLによるネザースターの製造見直し(マター：削除、Pristine：作成量減少)
* 学習に必要な量のコストを大幅に上昇