### PR TITLE
BasicPlateを含む加工RF/t量の低下及びスクリプト名のリファクタリング

### DIFF
--- a/scripts/MM/arc_metallurgic_fabricator.zs
+++ b/scripts/MM/arc_metallurgic_fabricator.zs
@@ -9,7 +9,7 @@ val machineName="arc_metallurgic_fabricator";
 recipes.remove(<nuclearcraft:part>);
 val basicplate = mods.modularmachinery.RecipeBuilder.newBuilder("BasicPlate_processing", machineName, 160, 1);
 
-basicplate.addEnergyPerTickInput(640);
+basicplate.addEnergyPerTickInput(320);
 basicplate.addItemInput(<ore:ingotLead>, 16);
 basicplate.addItemInput(<contenttweaker:tungsten_ingot>);
 basicplate.addItemInput(<ore:plateSteel>, 16);
@@ -20,7 +20,7 @@ basicplate.build();
 recipes.remove(<nuclearcraft:part:1>);
 val advplate = mods.modularmachinery.RecipeBuilder.newBuilder("AdvancedPlate_processing", machineName, 160, 1);
 
-advplate.addEnergyPerTickInput(1280);
+advplate.addEnergyPerTickInput(640);
 advplate.addItemInput(<nuclearcraft:part>*16);
 advplate.addItemInput(<ore:ingotTough>, 32);
 advplate.addItemInput(<ore:dustRedstone>, 64);
@@ -31,7 +31,7 @@ advplate.build();
 recipes.remove(<nuclearcraft:part:2>);
 val duplate = mods.modularmachinery.RecipeBuilder.newBuilder("DUPlate_processing", machineName, 160, 1);
 
-duplate.addEnergyPerTickInput(2560);
+duplate.addEnergyPerTickInput(1280);
 duplate.addItemInput(<nuclearcraft:part:1>*16);
 duplate.addItemInput(<nuclearcraft:uranium:9>*32);
 duplate.addItemInput(<ore:dustSulfur>, 64);
@@ -42,7 +42,7 @@ duplate.build();
 recipes.remove(<nuclearcraft:part:3>);
 val eliteplate = mods.modularmachinery.RecipeBuilder.newBuilder("ElitePlate_processing", machineName, 160, 1);
 
-eliteplate.addEnergyPerTickInput(5120);
+eliteplate.addEnergyPerTickInput(2560);
 eliteplate.addItemInput(<nuclearcraft:part:2>*16);
 eliteplate.addItemInput(<nuclearcraft:compound:1>*32);
 eliteplate.addItemInput(<ore:ingotBoron>, 64);


### PR DESCRIPTION
refs - #48, #49
* BasicPlateを含む、AMFでの作成に必要なRF/tを低下
* スクリプト名のリファクタリング(copy句の削除)