### PR TITLE
AE2の解禁難易度の低下

### DIFF
--- a/config/environmentaltech/multiblocks/void_miner/ore/tier_1.json
+++ b/config/environmentaltech/multiblocks/void_miner/ore/tier_1.json
@@ -489,6 +489,16 @@
       "target": "black",
       "weight": 4,
       "id": "contenttweaker:tiny_tungsten_dust"
+    },
+    {
+      "target": "light_blue",
+      "weight": 187,
+      "id": "OD:oreCertusQuartz"
+    },
+    {
+      "target": "light_blue",
+      "weight": 109,
+      "id": "OD:oreChargedCertusQuartz"
     }
   ]
 }

--- a/config/environmentaltech/multiblocks/void_miner/ore/tier_2.json
+++ b/config/environmentaltech/multiblocks/void_miner/ore/tier_2.json
@@ -494,6 +494,16 @@
       "target": "black",
       "weight": 6,
       "id": "contenttweaker:tiny_tungsten_dust"
+    },
+    {
+      "target": "light_blue",
+      "weight": 187,
+      "id": "OD:oreCertusQuartz"
+    },
+    {
+      "target": "light_blue",
+      "weight": 109,
+      "id": "OD:oreChargedCertusQuartz"
     }
   ]
 }

--- a/config/environmentaltech/multiblocks/void_miner/ore/tier_3.json
+++ b/config/environmentaltech/multiblocks/void_miner/ore/tier_3.json
@@ -499,6 +499,16 @@
       "target": "black",
       "weight": 8,
       "id": "contenttweaker:tiny_tungsten_dust"
+    },
+    {
+      "target": "light_blue",
+      "weight": 187,
+      "id": "OD:oreCertusQuartz"
+    },
+    {
+      "target": "light_blue",
+      "weight": 109,
+      "id": "OD:oreChargedCertusQuartz"
     }
   ]
 }

--- a/scripts/AE2.zs
+++ b/scripts/AE2.zs
@@ -40,3 +40,17 @@ mods.actuallyadditions.MiningLens.removeStoneOre(<ore:oreChargedCertusQuartz>);
 # Infinity Booster Card
 recipes.remove(<ae2wtlib:infinity_booster_card>);
 recipes.addShaped(<ae2wtlib:infinity_booster_card> * 1, [[<contenttweaker:block_tungsten:0>, <fluxnetworks:gargantuanfluxstorage>, <contenttweaker:block_tungsten:0>], [<avaritia:block_resource:2>, <appliedenergistics2:material:42>, <avaritia:block_resource:2>],[<contenttweaker:block_tungsten:0>, <fluxnetworks:gargantuanfluxstorage>, <contenttweaker:block_tungsten:0>]]);
+
+# ItDとEIOから作るアドホック用のパーツレシピ
+
+// 1k ME Storage Component
+recipes.addShaped(<appliedenergistics2:material:35> * 1, [[<integrateddynamics:crystalized_menril_chunk>, <enderio:item_material:42>, <integrateddynamics:crystalized_menril_chunk>], [<integrateddynamics:variable_transformer:0>, <appliedenergistics2:material:24>, <integrateddynamics:variable_transformer:1>],[<integrateddynamics:crystalized_menril_chunk>, <enderio:item_material:42>, <integrateddynamics:crystalized_menril_chunk>]]);
+
+// Energy Acceptor
+recipes.addShaped(<appliedenergistics2:energy_acceptor> * 1, [[<contenttweaker:tungsten_ingot>, <enderio:block_dark_fused_quartz:0>, <contenttweaker:tungsten_ingot>], [<enderio:block_dark_fused_quartz:0>, <enderio:item_material:15>, <enderio:block_dark_fused_quartz:0>],[<contenttweaker:tungsten_ingot>, <enderio:block_dark_fused_quartz:0>, <contenttweaker:tungsten_ingot>]]);
+
+// ME Glass Cable - Fluix
+recipes.addShaped(<appliedenergistics2:part:16> * 6, [[<integratedterminals:chorus_glass>, <integratedterminals:chorus_glass>, <integratedterminals:chorus_glass>], [<enderio:item_material:15>, <appliedenergistics2:part:140>, <enderio:item_material:15>],[<integratedterminals:chorus_glass>, <integratedterminals:chorus_glass>, <integratedterminals:chorus_glass>]]);
+
+// ME Terminal
+recipes.addShaped(<appliedenergistics2:part:380> * 1, [[<integrateddynamics:crystalized_chorus_chunk>, <integratedterminals:chorus_glass>, <integrateddynamics:crystalized_chorus_chunk>], [<appliedenergistics2:part:180>, <integratedterminals:part_terminal_storage_item>, <appliedenergistics2:part:16>],[<integrateddynamics:crystalized_chorus_chunk>, <integratedterminals:chorus_glass>, <integrateddynamics:crystalized_chorus_chunk>]]);


### PR DESCRIPTION
refs - #72
* アドホックネットワーク程度であればEIOとItDの素材で最低限構築できるように
* VoidOreMiner1からの稼働でもケルタスクォーツが入手できるように