### PR TITLE
DeepMobLearningのPristineMatterで作れるアイテムの強化

### DIFF
--- a/config/deepmoblearning.cfg
+++ b/config/deepmoblearning.cfg
@@ -250,6 +250,11 @@ general {
         minecraft:dragon_egg,1,0
         draconicevolution:dragon_heart,1,0
         draconicevolution:draconium_dust,4,0
+        iceandfire:fire_dragon_blood,24,0
+        iceandfire:ice_dragon_blood,24,0
+        iceandfire:dragonbone,24,0
+        iceandfire:dragonscale_gray,10,0
+        iceandfire:dragonscale_silver,10,0
      >
 
     # Enderman
@@ -321,7 +326,7 @@ general {
 
     # Wither
     S:wither <
-        minecraft:nether_star,1,0
+        minecraft:nether_star,4,0
      >
 
     # Wither Skeleton


### PR DESCRIPTION
refs - #116
* ネザースターの作成数を1→4に増加
* ドラゴン関係のアイテムを追加