### PR TITLE
NuclearCraftのUranium以外のRTG発電量を強化

### DIFF
--- a/config/nuclearcraft.cfg
+++ b/config/nuclearcraft.cfg
@@ -757,9 +757,9 @@ generators {
     # RF/t generated. Order: Uranium, Plutonium, Americium, Californium.
     I:rtg_power <
         4
+        200
         100
-        50
-        400
+        800
      >
 
     # RF/t generated. Order: Basic, Advanced, DU, Elite.


### PR DESCRIPTION
refs - #123