### PR TITLE
α-0.3.1 リリース用

### DIFF
--- a/config/actuallyadditions.cfg
+++ b/config/actuallyadditions.cfg
@@ -545,7 +545,7 @@ other {
     I:"Flax: Amount"=8
 
     # Should caves with trees and grass randomly generate underground?
-    B:"Generate Lush Caves"=true
+    B:"Generate Lush Caves"=false
 
     # Should the Jam Villager and his House generate in the world?
     B:"Jam Villager: Existence"=true

--- a/config/brandon3055/CustomFusionRecipes.json
+++ b/config/brandon3055/CustomFusionRecipes.json
@@ -213,5 +213,32 @@
             "contenttweaker:energized_tungsten_ingot",
             "contenttweaker:energized_tungsten_ingot"
         ]
+    },
+    {
+        "mode": "ADD",
+        "result": "forge:bucketfilled,1,0,{FluidName:infinity,Amount: 1000}",
+        "catalyst": "forge:bucketfilled,1,0,{FluidName:neutron,Amount: 1000}",
+        "energy": 100000000000,
+        "tier": 3,
+        "ingredients": [
+            "avaritia:block_resource,1,1",
+            "avaritia:block_resource,1,1",
+            "avaritiatweaks:enhancement_crystal",
+            "avaritiatweaks:enhancement_crystal",
+            "enderio:block_infinity,1,2",
+            "enderio:block_infinity,1,2",
+            "draconicadditions:chaotic_energy_core",
+            "draconicadditions:chaotic_energy_core",
+            "notenoughrtgs:rtg_californium_dense",
+            "notenoughrtgs:rtg_californium_dense",
+            "bloodmagic:item_demon_crystal,64,1",
+            "bloodmagic:item_demon_crystal,64,2",
+            "bloodmagic:item_demon_crystal,64,3",
+            "bloodmagic:item_demon_crystal,64,4",
+            "extrabotany:material,1,1",
+            "extrabotany:material,1,1",
+            "astralsorcery:itemperkgem,1,1",
+            "astralsorcery:itemperkgem,1,1"
+        ]
     }
 ]

--- a/config/deepmoblearning.cfg
+++ b/config/deepmoblearning.cfg
@@ -250,6 +250,11 @@ general {
         minecraft:dragon_egg,1,0
         draconicevolution:dragon_heart,1,0
         draconicevolution:draconium_dust,4,0
+        iceandfire:fire_dragon_blood,24,0
+        iceandfire:ice_dragon_blood,24,0
+        iceandfire:dragonbone,24,0
+        iceandfire:dragonscale_gray,10,0
+        iceandfire:dragonscale_silver,10,0
      >
 
     # Enderman
@@ -321,7 +326,7 @@ general {
 
     # Wither
     S:wither <
-        minecraft:nether_star,1,0
+        minecraft:nether_star,4,0
      >
 
     # Wither Skeleton

--- a/config/environmentaltech/multiblocks/void_miner/ore/tier_3.json
+++ b/config/environmentaltech/multiblocks/void_miner/ore/tier_3.json
@@ -501,6 +501,11 @@
       "id": "contenttweaker:tiny_tungsten_dust"
     },
     {
+      "target": "black",
+      "weight": 6,
+      "id": "contenttweaker:tungsten_dust"
+    },
+    {
       "target": "light_blue",
       "weight": 187,
       "id": "OD:oreCertusQuartz"

--- a/config/environmentaltech/multiblocks/void_miner/ore/tier_4.json
+++ b/config/environmentaltech/multiblocks/void_miner/ore/tier_4.json
@@ -514,6 +514,11 @@
       "target": "black",
       "weight": 10,
       "id": "contenttweaker:tiny_tungsten_dust"
+    },
+    {
+      "target": "black",
+      "weight": 8,
+      "id": "contenttweaker:tungsten_dust"
     }
   ]
 }

--- a/config/environmentaltech/multiblocks/void_miner/ore/tier_5.json
+++ b/config/environmentaltech/multiblocks/void_miner/ore/tier_5.json
@@ -519,6 +519,16 @@
       "target": "black",
       "weight": 15,
       "id": "contenttweaker:tiny_tungsten_dust"
+    },
+    {
+      "target": "black",
+      "weight": 12,
+      "id": "contenttweaker:tungsten_dust"
+    },
+    {
+      "target": "black",
+      "weight": 10,
+      "id": "contenttweaker:unrefined_tungsten_bloom"
     }
   ]
 }

--- a/config/environmentaltech/multiblocks/void_miner/ore/tier_6.json
+++ b/config/environmentaltech/multiblocks/void_miner/ore/tier_6.json
@@ -521,6 +521,16 @@
       "id": "contenttweaker:tiny_tungsten_dust"
     },
     {
+      "target": "black",
+      "weight": 22,
+      "id": "contenttweaker:tungsten_dust"
+    },
+    {
+      "target": "black",
+      "weight": 18,
+      "id": "contenttweaker:unrefined_tungsten_bloom"
+    },
+    {
       "target": "gray",
       "weight": 9,
       "id": "avaritia:resource:2"

--- a/config/harvestcraft.cfg
+++ b/config/harvestcraft.cfg
@@ -154,7 +154,7 @@ drops {
 gardens {
     B:enablearidgardenGeneration=true
     B:enablefrostgardenGeneration=true
-    B:enablegardenSpread=true
+    B:enablegardenSpread=false
     B:enableshadedgardenGeneration=true
     B:enablesoggygardenGeneration=true
     B:enabletropicalgardenGeneration=true

--- a/config/industrialforegoing.cfg
+++ b/config/industrialforegoing.cfg
@@ -76,13 +76,13 @@ machines {
 
     petrified_fuel_generator {
         # This config only changes for how much time a fuel burns. (FuelBurningTime = ItemBurningTime*%value%) [range: 0.0 ~ 3.4028235E38, default: 0.75]
-        S:burnTimeMultiplier=0.75
+        S:burnTimeMultiplier=0.375
 
         # If disabled it will be removed from the game. [default: true]
         B:enabled=true
 
         # This config changes the RF/t the fuel produces based in the fuel burning time also changing for how much it burns. (RF/t = FuelBurningTime/%value%) [range: 1 ~ 2147483647, default: 20]
-        I:timeModifier=20
+        I:timeModifier=40
 
         # Machine can perform a work action [default: false]
         B:workDisabled=false

--- a/config/nuclearcraft.cfg
+++ b/config/nuclearcraft.cfg
@@ -757,9 +757,9 @@ generators {
     # RF/t generated. Order: Uranium, Plutonium, Americium, Californium.
     I:rtg_power <
         4
+        200
         100
-        50
-        400
+        800
      >
 
     # RF/t generated. Order: Basic, Advanced, DU, Elite.

--- a/config/rftools/dimlets.json
+++ b/config/rftools/dimlets.json
@@ -86,6 +86,21 @@
       "dimlet": true
     }
   },
+  {
+    "filter": {
+      "mod": "draconicevolution",
+      "name": "blockdraconium",
+      "type": "material"
+    },
+    "settings": {
+      "rarity": 5,
+      "create": 40000,
+      "maintain": 24000,
+      "ticks": 8000,
+      "worldgen": true,
+      "dimlet": true
+    }
+  },
   "Everything below this line will be regenerated from defaults every time. Remove this line if you do not want that",
   {
     "filter": {

--- a/config/rftools/dimlets.json
+++ b/config/rftools/dimlets.json
@@ -89,7 +89,8 @@
   {
     "filter": {
       "mod": "draconicevolution",
-      "name": "blockdraconium",
+      "name": "draconium_block",
+      "meta": 0,
       "type": "material"
     },
     "settings": {

--- a/config/solcarrot.cfg
+++ b/config/solcarrot.cfg
@@ -20,11 +20,26 @@ general {
 
     # A list of numbers of unique foods you need to eat to unlock each milestone, in ascending order.
     I:"Milestone amounts" <
-        5
-        10
-        15
-        20
-        25
+        6
+        12
+        18
+        24
+        30
+        36
+        42
+        48
+        54
+        60
+        66
+        72
+        78
+        84
+        90
+        96
+        102
+        108
+        114
+        120
      >
 
     # The minimum hunger value foods need to provide in order to count for milestones, in half drumsticks.

--- a/scripts/IndustrialForegoing.zs
+++ b/scripts/IndustrialForegoing.zs
@@ -21,3 +21,7 @@ for item in removeList {
     recipes.remove(item);
     mods.jei.JEI.hide(item);
 }
+
+# Replace Petrified Fuel Generator recipes
+recipes.remove(<industrialforegoing:petrified_fuel_generator>);
+recipes.addShaped(<industrialforegoing:petrified_fuel_generator> * 1, [[<industrialforegoing:pink_slime_ingot>, <industrialforegoing:plastic>, <industrialforegoing:pink_slime_ingot>], [<redstonerepository:material:3>, <teslacorelib:machine_case>, <redstonerepository:material:3>],[<industrialforegoing:plastic>, <actuallyadditions:block_coal_generator>, <industrialforegoing:plastic>]]);

--- a/scripts/NajarantisCustom.zs
+++ b/scripts/NajarantisCustom.zs
@@ -1,3 +1,10 @@
+# タングステンに鉱石辞書を追加する
+val oreDictIngotTungsten = <ore:ingotTungsten>;
+val oreDictBlockTungsten = <ore:blockTungsten>;
+
+oreDictIngotTungsten.add(<contenttweaker:tungsten_ingot>);
+oreDictBlockTungsten.add(<contenttweaker:block_tungsten>);
+
 # タングステン加工系
 recipes.addShaped(<contenttweaker:tungsten_dust>, [[<contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>], [<contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>],[<contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>]]);
 mods.thermalexpansion.Transposer.addFillRecipe(<contenttweaker:hot_tungsten_ingot>, <contenttweaker:tungsten_dust>, <liquid:pyrotheum> * 500, 150000);

--- a/scripts/NajarantisCustom.zs
+++ b/scripts/NajarantisCustom.zs
@@ -7,6 +7,8 @@ oreDictBlockTungsten.add(<contenttweaker:block_tungsten>);
 
 # タングステン加工系
 recipes.addShaped(<contenttweaker:tungsten_dust>, [[<contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>], [<contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>],[<contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>]]);
+recipes.addShapeless(<contenttweaker:tiny_tungsten_dust>*9, [<contenttweaker:unrefined_tungsten_bloom>]);
+
 mods.thermalexpansion.Transposer.addFillRecipe(<contenttweaker:hot_tungsten_ingot>, <contenttweaker:tungsten_dust>, <liquid:pyrotheum> * 500, 150000);
 mods.thermalexpansion.Transposer.addFillRecipe(<contenttweaker:impure_tungsten_ingot>, <contenttweaker:hot_tungsten_ingot>, <liquid:cryotheum> * 500, 150000);
 mods.thermalexpansion.Transposer.addFillRecipe(<contenttweaker:dithered_tungsten_ingot>, <contenttweaker:impure_tungsten_ingot>, <liquid:petrotheum> * 500, 150000);
@@ -42,9 +44,10 @@ mods.astralsorcery.Altar.addTraitAltarRecipe("", <contenttweaker:block_nebula_tu
     "astralsorcery.constellation.pelotrio"
 );
 recipes.addShaped(<contenttweaker:unrefined_tungsten_bloom> * 1, [[null, <contenttweaker:tiny_tungsten_dust>, null], [<contenttweaker:tiny_tungsten_dust>, <contenttweaker:tungsten_dust>, <contenttweaker:tiny_tungsten_dust>],[null, <contenttweaker:tiny_tungsten_dust>, null]]);
+recipes.addShapeless(<contenttweaker:tiny_tungsten_dust>*13, [<contenttweaker:unrefined_tungsten_bloom>]);
 mods.iceandfire.recipes.addFireDragonForgeRecipe(<contenttweaker:unrefined_tungsten_bloom>, <iceandfire:fire_dragon_blood>, <contenttweaker:incandescent_solid_tungsten_ingot>);
 mods.iceandfire.recipes.addIceDragonForgeRecipe(<contenttweaker:incandescent_solid_tungsten_ingot>, <iceandfire:ice_dragon_blood>, <contenttweaker:solid_tungsten_ingot>);
-mods.extrabotany.Pedestal.add(<contenttweaker:tungsten_ingot>*2, <contenttweaker:solid_tungsten_ingot>);
+mods.extrabotany.Pedestal.add(<contenttweaker:tungsten_ingot>*3, <contenttweaker:solid_tungsten_ingot>);
 
 # インゴット⇔ブロック
 val ING_CD = <contenttweaker:charged_draconium_ingot>;

--- a/scripts/NajarantisCustom.zs
+++ b/scripts/NajarantisCustom.zs
@@ -17,16 +17,18 @@ mods.botania.ElvenTrade.addRecipe(
     [<contenttweaker:blessed_tungsten_ingot>, <botania:manaringgreater>.withTag({mana: 0})],
     [<contenttweaker:tungsten_ingot>, <botania:manaresource:5>, <botania:manaresource:5>, <botania:manaresource:5>, <botania:manaresource:5>, <botania:manaringgreater>.withTag({mana: 2000000})]
 );
-mods.bloodmagic.BloodAltar.addRecipe(<contenttweaker:living_tungsten_ingot>, <contenttweaker:tungsten_ingot>, 4, 45000, 150, 0);
+mods.bloodmagic.AlchemyTable.addRecipe(<contenttweaker:living_tungsten_ingot>*4,
+    [<contenttweaker:tungsten_ingot>, <contenttweaker:tungsten_ingot>, <contenttweaker:tungsten_ingot>, <contenttweaker:tungsten_ingot>, <bloodmagic:points_upgrade>, <bloodmagic:component:18>],
+    1500000, 200, 4);
 val CC = <astralsorcery:itemcelestialcrystal>;
 val RG = <astralsorcery:itemcraftingcomponent:4>;
 val SS = <astralsorcery:itemcraftingcomponent:2>;
 val SM = <astralsorcery:itemcraftingcomponent:1>;
-mods.astralsorcery.Altar.addTraitAltarRecipe("", <contenttweaker:nebula_tungsten_ingot>,
+mods.astralsorcery.Altar.addTraitAltarRecipe("", <contenttweaker:block_nebula_tungsten>,
     95, 1200,
     [
         CC, RG, CC,
-        RG, <contenttweaker:tungsten_ingot>, RG,
+        RG, <contenttweaker:block_tungsten>, RG,
         CC, RG, CC,
         null, null, null, null,
         SS, SS, SM, SM, SM, SM, SS, SS,

--- a/scripts/NajarantisCustom.zs
+++ b/scripts/NajarantisCustom.zs
@@ -7,7 +7,7 @@ oreDictBlockTungsten.add(<contenttweaker:block_tungsten>);
 
 # タングステン加工系
 recipes.addShaped(<contenttweaker:tungsten_dust>, [[<contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>], [<contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>],[<contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>, <contenttweaker:tiny_tungsten_dust>]]);
-recipes.addShapeless(<contenttweaker:tiny_tungsten_dust>*9, [<contenttweaker:unrefined_tungsten_bloom>]);
+recipes.addShapeless(<contenttweaker:tiny_tungsten_dust>*9, [<contenttweaker:tungsten_dust>]);
 
 mods.thermalexpansion.Transposer.addFillRecipe(<contenttweaker:hot_tungsten_ingot>, <contenttweaker:tungsten_dust>, <liquid:pyrotheum> * 500, 150000);
 mods.thermalexpansion.Transposer.addFillRecipe(<contenttweaker:impure_tungsten_ingot>, <contenttweaker:hot_tungsten_ingot>, <liquid:cryotheum> * 500, 150000);

--- a/scripts/Psi.zs
+++ b/scripts/Psi.zs
@@ -1,0 +1,3 @@
+// Psimetal CAD Assembly
+recipes.remove(<psi:cad_assembly:2>);
+recipes.addShaped(<psi:cad_assembly:2> * 1, [[<redstonearsenal:material:96>, <psi:material:1>, <psi:material:1>], [<psi:material:1>, <psi:material:1>, null],[null, null, null]]);

--- a/scripts/ThermalExp_and_Foundation/Gears.zs
+++ b/scripts/ThermalExp_and_Foundation/Gears.zs
@@ -168,8 +168,8 @@ recipes.addShaped(<thermalfoundation:material:293>, [
 ]);
 
 # --- Lumium
-recipes.remove(<thermalfoundation:material:293>);
-recipes.addShaped(<thermalfoundation:material:293>, [
+recipes.remove(<thermalfoundation:material:294>);
+recipes.addShaped(<thermalfoundation:material:294>, [
     [null, <ore:ingotLumium>, null],
     [<ore:ingotLumium>, <ore:blockLumium>, <ore:ingotLumium>],
     [null, <ore:ingotLumium>, null]

--- a/scripts/TinkersConstruct.zs
+++ b/scripts/TinkersConstruct.zs
@@ -14,3 +14,8 @@ recipes.remove(<plustic:centrifuge>);
 # 液化石炭を乾式製錬炉で溶かせないようにする
 
 mods.tconstruct.Melting.removeRecipe(<liquid:coal>);
+
+# - ItemRackを作成できなくする
+
+recipes.remove(<tconstruct:rack>);
+mods.jei.JEI.hide(<tconstruct:rack>.withTag({textureBlock: {id: "minecraft:wooden_slab", Count: 1 as byte, Damage: 0 as short}}));

--- a/scripts/TinkersConstruct.zs
+++ b/scripts/TinkersConstruct.zs
@@ -19,3 +19,7 @@ mods.tconstruct.Melting.removeRecipe(<liquid:coal>);
 
 recipes.remove(<tconstruct:rack>);
 mods.jei.JEI.hide(<tconstruct:rack>.withTag({textureBlock: {id: "minecraft:wooden_slab", Count: 1 as byte, Damage: 0 as short}}));
+
+# - InfinityIngotを乾式製錬炉で溶かせないように変更する
+
+mods.tconstruct.Melting.removeRecipe(<liquid:infinity>);


### PR DESCRIPTION
* refs - #109 WoodPlankとItemRackのレシピ競合を修正、ItemRackは作成できなくなりました。
* refs - #110 CompactingDrawerでTungstenを圧縮・分解できるようにしました。
* refs - #111 CarrotEditionのHP増加のバランス調整を行いました。マイルストーンを6に増加しましたが、マイルストーンの上限値を120に増加しました。
* refs - #112 PsiのPsimetal製CADのレシピを変更しました。
* refs - #113 PetrifiedFuelGeneratorの作成コスト及び出力RF/tを下方修正しました。
* refs - #114 液体Infinityの作成方法を高難度化しました。
* refs - #115 派生タングステンのレシピ(Nebula、Freshy)を変更しました。
* refs - #116 DMLのPristineMatterで作れるアイテムを一部追加または強化を行いました。
* refs - #117 上位のVoidOreMinerで入手できるタングステンの量を増加しました。
* refs - #118 未精錬のタングステンの粉末の相互変換レシピを追加しました。
* refs - #119 ドラゴンを利用したタングステンの精錬時の生成物を、2個から3個に増加しました。
* refs - #120 DraconiumBlockのDimletを新規に追加しました。
* refs - #121 ActuallyAdditionsの地下空洞の生成を切りました。
* refs - #122 HarvestCraftのGardenの自己増殖をしないように設定しました。
* refs - #123 NuclearCraftの一部RTGの発電量を上方修正しました。
* refs - #124 LumiumGearの作業台クラフトレシピを修正しました。